### PR TITLE
ISSUE #25 - add action text

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+@import "trix/dist/trix.css";
+
 body{
   background-color: #F7F7F7;
 }

--- a/app/assets/stylesheets/communities.scss
+++ b/app/assets/stylesheets/communities.scss
@@ -5,6 +5,11 @@
   }
 }
 
+.card{
+  height: 175px;
+  overflow: auto;
+}
+
 .card:hover{
   box-shadow: 0 0 11px rgba(33,33,33,.2);
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,3 +22,6 @@ document.addEventListener("turbolinks:load", () => {
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
+
+require("trix")
+require("@rails/actiontext")

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import "trix/dist/trix"
+import "@rails/actiontext"
 import "src/bookmarks.js"
 import "src/awards.js"
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  has_rich_text :content
   validates :title , presence: true , length: { minimum: 3 , maximum: 70 }
   validates :content , presence: true
   belongs_to :user

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/bookmarked_posts/index.html.slim
+++ b/app/views/bookmarked_posts/index.html.slim
@@ -13,7 +13,7 @@ h1.d-flex.justify-content-center
           h5.card-title
             = post.title
           p.card-text
-            = post.content
+            == post.content
           p.card-text
             small.text-muted
               | Created by&#160

--- a/app/views/communities/show.html.slim
+++ b/app/views/communities/show.html.slim
@@ -23,7 +23,7 @@ hr
           h5.card-title
             = post.title
           p.card-text
-            = post.content
+            == post.content
           p.card-text
             small.text-muted
               | Created by&#160

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -2,7 +2,7 @@
   = f.label :title, class: "form-label"
   = f.text_field :title, class: "form-control", placeholder: "Title"
   = f.label :content, class: "form-label"
-  = f.text_area :content, size: "5x10", class: "form-control", style:"margin-bottom:2%", placeholder: "Your text here..."
+  = f.rich_text_area :content, class: "form-control", style:"margin-bottom:2%", placeholder: "Your text here..."
   = f.hidden_field :user_id , value: current_user.id
   = f.hidden_field :community_id , value: community.id
   - if action_name == 'edit'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -15,10 +15,9 @@
          i#bookmark_icon.bi class="#{@bookmarked ? 'bi-bookmark' : 'bi-bookmark-fill'}" data-id="#{@post.id}"
          i#award_icon.bi.bi-gift data-bs-toggle="modal" data-bs-target="#awardsSelectModal"
 
-
     hr
-    p.card-text
-      = @post.content
+    .card-text
+      == @post.content
     hr
     #post-awards
       - @post.awards.includes(:image_blob).each do |award|

--- a/db/migrate/20211202133948_create_action_text_tables.action_text.rb
+++ b/db/migrate/20211202133948_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/migrate/20211202134340_remove_content_from_posts.rb
+++ b/db/migrate/20211202134340_remove_content_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveContentFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :posts, :content
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,13 @@
   resolved "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.1.4.tgz"
   integrity sha512-0LmSKJTuo2dL6BQ+9xxLnS9lbkyfz2mBGeBnQ2J7o9Bn0l0q+ZC6VuoZMZZXPvABI4QT7Nfknv5WhfKYL+boew==
 
+"@rails/actiontext@^6.1.4-1":
+  version "6.1.4-1"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.1.4-1.tgz#c75fbeeb7860c2f508150ad003c0c0d0c97c7584"
+  integrity sha512-dS7AdkJtSyuX2PXipCTNOKEg5G/ftwS+FmM5+8Zxbo35tgs08hfYFPh0muoj5eEkshwV67kEEV/iHgX8PMLh4w==
+  dependencies:
+    "@rails/activestorage" "^6.0.0"
+
 "@rails/activestorage@^6.0.0":
   version "6.1.4"
   resolved "https://registry.npmjs.org/@rails/activestorage/-/activestorage-6.1.4.tgz"
@@ -6509,6 +6516,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+trix@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.3.1.tgz#ccce8d9e72bf0fe70c8c019ff558c70266f8d857"
+  integrity sha512-BbH6mb6gk+AV4f2as38mP6Ucc1LE3OD6XxkZnAgPIduWXYtvg2mI3cZhIZSLqmMh9OITEpOBCCk88IVmyjU7bA==
 
 ts-pnp@^1.1.6:
   version "1.2.0"


### PR DESCRIPTION
- New and update forms now have action text. ( + images )

form:
<img width="1047" alt="Screenshot 2021-12-03 at 09 47 50" src="https://user-images.githubusercontent.com/90070548/144565169-1c344e0e-56b1-43dc-8afc-68bb91ad1a74.png">
show contents: 
<img width="1047" alt="Screenshot 2021-12-03 at 09 48 13" src="https://user-images.githubusercontent.com/90070548/144565178-261b5cd7-24d4-4374-8659-63183f96dcde.png">
