### PR TITLE
Issue #101 - SCSS fixes

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,6 +6,6 @@
     }
   ],
   "rules": {
-    "color-function-notation": false
+      "color-function-notation": null
     }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,5 +4,8 @@
     {
       "files": ["app/assets/**/*.scss"]
     }
-  ]
+  ],
+  "rules": {
+    "color-function-notation": false
+    }
 }

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,13 +1,3 @@
-//
-// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
-// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
-// inclusion directly in any other asset bundle and remove this file.
-//
-//= require trix/dist/trix
-
-// We need to override trix.css’s image gallery styles to accommodate the
-// <action-text-attachment> element we wrap around attachments. Otherwise,
-// images in galleries will be squished by the max-width: 33%; rule.
 .trix-content {
   .attachment-gallery {
     > action-text-attachment,

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -6,9 +6,10 @@
       padding: 0 0.5em;
       max-width: 33%;
     }
-
+    /* stylelint-disable */
     &.attachment-gallery--2,
     &.attachment-gallery--4 {
+    /* stylelint-enable */
       > action-text-attachment,
       > .attachment {
         flex-basis: 50%;
@@ -17,7 +18,7 @@
     }
   }
 
-  action-text-attachment {
+  .trix-content .trix-content action-text-attachment {
     .attachment {
       padding: 0 !important;
       max-width: 100% !important;

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -6,10 +6,10 @@
       padding: 0 0.5em;
       max-width: 33%;
     }
-    /* stylelint-disable */
+    /* stylelint-disable selector-class-pattern */
     &.attachment-gallery--2,
     &.attachment-gallery--4 {
-    /* stylelint-enable */
+      /* stylelint-enable selector-class-pattern */
       > action-text-attachment,
       > .attachment {
         flex-basis: 50%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,11 +12,10 @@ body {
   padding-right: 5%;
 }
 
-/* stylelint-disable */
+/* stylelint-disable-next-line selector-class-pattern */
 .tagify__tag-text {
   color: black;
 }
-/* stylelint-enable */
 
 .alerts {
   margin-bottom: 20px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,9 +12,11 @@ body {
   padding-right: 5%;
 }
 
+/* stylelint-disable */
 .tagify__tag-text {
   color: black;
 }
+/* stylelint-enable */
 
 .alerts {
   margin-bottom: 20px;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -12,7 +12,7 @@
 }
 
 .comment-block {
-  margin: 10px 0px;
+  margin: 10px 0;
 }
 
 .comments-header {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -28,7 +28,7 @@
 
 .card-img-top {
   width: 100%;
-  height:500px;
+  height: 500px;
   object-fit: cover;
 }
 


### PR DESCRIPTION
Apakšā ir bildes ar erroru un paskaidrojums kapec tas netika labotas

1.  
<img width="527" alt="Screenshot 2022-01-04 at 13 06 49" src="https://user-images.githubusercontent.com/90070548/148050176-337b89ec-4002-491a-a7fd-73ffda8fc712.png">
nevareju labot, jo tas ir ne manis veidotas klases, pie kuram es netieku klat, jo pienemu ka tiek generetas no node modules, tapec to nosaukumus nevaru nomainit

2.
<img width="544" alt="Screenshot 2022-01-04 at 13 09 08" src="https://user-images.githubusercontent.com/90070548/148050441-73984739-4e9a-4227-8593-ef3511a8b7af.png">
nelaboju, jo ja es izmantoju stylelint "modern" risinajumu, tad  vairs neatpazist parametrus jo tie netiek atdaliti vairs ar komatu.

3.
<img width="825" alt="Screenshot 2022-01-04 at 13 10 47" src="https://user-images.githubusercontent.com/90070548/148050628-5d3ff4f1-417e-4656-bc4b-55d4fc898f46.png">
Censoties labot, kad pievienoju piedavato selectoru, man stylelint pa jaunam saka lai pievienoju to pasu selectoru.
